### PR TITLE
Fix test-suite name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - ember-beta
           - ember-canary
         include:
-           - test-suite: "test:one ember-canary"
+           - test-suite: ember-canary
              allow-failure: true
 
     steps:


### PR DESCRIPTION
This fixes the CI matrix so that it correctly configures the `ember-canary` scenario to be allowed to fail instead of adding a non-existent scenario that then fails for sure…