### PR TITLE
chore: remove .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}


### PR DESCRIPTION
- removes .bowerrc
It raises warning when running the ember server