### PR TITLE
chore: Drop node - set minimal node version to >=16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - run: yarn install --frozen-lockfile
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - run: yarn install --frozen-lockfile
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - run: yarn install
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - run: yarn install --no-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm publish

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"
+  },
+  "volta": {
+    "node": "16.20.0"
   }
 }

--- a/packages/ember-cookies/package.json
+++ b/packages/ember-cookies/package.json
@@ -51,7 +51,7 @@
     "rollup": "^2.74.1"
   },
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 16.*"
   },
   "ember": {
     "edition": "octane"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -75,7 +75,7 @@
     "crypto"
   ],
   "engines": {
-    "node": ">= 14.*"
+    "node": ">= 16.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
https://github.com/nodejs/release#release-schedule

Node 14 has reached its EOL
Node 16 will reach it later this year our minimal supported version