### PR TITLE
chore: add crypto and node-fetch to fastbootDependencies

### DIFF
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -69,6 +69,10 @@
     "symlink-or-copy": "^1.1.8",
     "webpack": "^5.70.0"
   },
+  "fastbootDependencies": [
+    "node-fetch",
+    "crypto"
+  ],
   "engines": {
     "node": ">= 14.*"
   },


### PR DESCRIPTION
Fixes

```
(node:11219) UnhandledPromiseRejectionWarning: Error: Unable to require module 'crypto' because it was not in the whitelist.
    at Object.require (/Users/bobrystoteles/Projects/oss/ember-cookies/node_modules/fastboot/src/fastboot-schema.js:191:15)
    at Module.callback (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/addon-tree-output/@ember-data/store/index-8b77b852.js:509:1)
    at Module.exports (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:106:1)
    at Module._reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:104:1)
    at Module._reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:104:1)
    at Module._reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:143:1)
    at Module.reify (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:130:1)
    at Module.exports (/Users/bobrystoteles/Projects/oss/ember-cookies/packages/test-app/dist/assets/vendor/loader/loader.js:104:1)
```