### PR TITLE
chore: run ember-default scenario in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-lts-3.28
+          - ember-default
           - ember-release
           - ember-beta
           - ember-canary


### PR DESCRIPTION
Adds `ember-default` scenario to CI.
This will make sure that the default package.json packages are not broken.