### PR TITLE
chore: add @ember/string to the test-app

### DIFF
--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -25,6 +25,7 @@
     "@babel/eslint-parser": "^7.17.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
+    "@ember/string": "^3.0.1",
     "@embroider/test-setup": "1.8.3",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,6 +1018,13 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/string@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.1.tgz#42cf032031a4432c2dd69c327ae1876d2c13df9c"
+  integrity sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+
 "@ember/test-helpers@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.8.1.tgz#20f2e30d48172c2ff713e1db7fbec5352f918d4e"


### PR DESCRIPTION
- v5 ember requires `@ember/string` to be an explicit dependency.