### PR TITLE
chore: allow Ember v5 to fail on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         include:
            - test-suite: ember-canary
              allow-failure: true
+           - test-suite: ember-beta
+             allow-failure: true
+           - test-suite: ember-release
+             allow-failure: true
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
relates to #791 