### PR TITLE
feat(breaking): replace polyfills assign with Object.assign

### DIFF
--- a/packages/ember-cookies/src/services/cookies.js
+++ b/packages/ember-cookies/src/services/cookies.js
@@ -3,10 +3,8 @@ import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import Service from '@ember/service';
-import { assign as emberAssign } from '@ember/polyfills';
 import { serializeCookie } from '../utils/serialize-cookie';
 const { keys } = Object;
-const assign = Object.assign || emberAssign;
 const DEFAULTS = { raw: false };
 const MAX_COOKIE_BYTE_LENGTH = 4096;
 
@@ -44,14 +42,14 @@ export default class CookiesService extends Service {
     }, {});
 
     let fastBootCookiesCache = this._fastBootCookiesCache || {};
-    fastBootCookies = assign({}, fastBootCookies, fastBootCookiesCache);
+    fastBootCookies = Object.assign({}, fastBootCookies, fastBootCookiesCache);
     this._fastBootCookiesCache = fastBootCookies;
 
     return this._filterCachedFastBootCookies(fastBootCookies);
   }
 
   read(name, options = {}) {
-    options = assign({}, DEFAULTS, options || {});
+    options = Object.assign({}, DEFAULTS, options || {});
     assert(
       'Domain, Expires, Max-Age, and Path options cannot be set when reading cookies',
       isEmpty(options.domain) &&
@@ -76,7 +74,7 @@ export default class CookiesService extends Service {
   }
 
   write(name, value, options = {}) {
-    options = assign({}, DEFAULTS, options || {});
+    options = Object.assign({}, DEFAULTS, options || {});
     assert(
       "Cookies cannot be set as signed as signed cookies would not be modifyable in the browser as it has no knowledge of the express server's signing key!",
       !options.signed
@@ -104,7 +102,7 @@ export default class CookiesService extends Service {
   }
 
   clear(name, options = {}) {
-    options = assign({}, options || {});
+    options = Object.assign({}, options || {});
     assert(
       'Expires, Max-Age, and raw options cannot be set when clearing cookies',
       isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.raw)
@@ -159,7 +157,7 @@ export default class CookiesService extends Service {
 
   _cacheFastBootCookie(name, value, options = {}) {
     let fastBootCache = this._fastBootCookiesCache || {};
-    let cachedOptions = assign({}, options);
+    let cachedOptions = Object.assign({}, options);
 
     if (cachedOptions.maxAge) {
       let expires = new Date();

--- a/packages/ember-cookies/src/test-support/clear-all-cookies.js
+++ b/packages/ember-cookies/src/test-support/clear-all-cookies.js
@@ -1,9 +1,6 @@
 import { assert } from '@ember/debug';
-import { assign as emberAssign } from '@ember/polyfills';
 import { isEmpty } from '@ember/utils';
 import { serializeCookie } from '../utils/serialize-cookie';
-
-const assign = Object.assign || emberAssign;
 
 export default function clearAllCookies(options = {}) {
   assert('Cookies cannot be set to be HTTP-only from a browser!', !options.httpOnly);
@@ -11,7 +8,7 @@ export default function clearAllCookies(options = {}) {
     'Expires, Max-Age, and raw options cannot be set when clearing cookies',
     isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.raw)
   );
-  options = assign({}, options, {
+  options = Object.assign({}, options, {
     expires: new Date(0),
   });
 


### PR DESCRIPTION
- removes @ember/polyfills's `assign` method
inherently drops IE11 support