### PR TITLE
chore(release): ember-cookies v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0
+
+* **BREAKING** :boom: Drops Ember v3, supports Ember v5. Refer to [Github Releases](https://github.com/mainmatter/ember-cookies/releases)
+
 # 0.5.2
 
 * A bug was fixed that prevented usage in projects that are not using FastBoot,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2",
+  "version": "0.1.0",
   "private": true,
   "repository": "https://github.com/simplabs/ember-cookies",
   "license": "MIT",

--- a/packages/ember-cookies/package.json
+++ b/packages/ember-cookies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cookies",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "description": "Cookies abstraction for Ember.js that works both in the browser as well as with Fastboot on the server.",
   "keywords": [
     "ember-addon"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-app",
-  "version": "0.5.2",
+  "version": "0.1.0",
   "description": "Test app for ember-cookies addon",
   "license": "MIT",
   "author": "",
@@ -40,7 +40,7 @@
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
-    "ember-cookies": "0.5.2",
+    "ember-cookies": "1.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",


### PR DESCRIPTION
- sets ember-cookies version to 1.0.0
- decreases versions for test-app and monorepo to 0.1.0. They are not a part of the release and don't need to match.
This should make versioning less confusing.

Will create a tag and release after the merge.