### PR TITLE
Fix type export of clearAllCookies

### DIFF
--- a/packages/ember-cookies/index.d.ts
+++ b/packages/ember-cookies/index.d.ts
@@ -9,7 +9,7 @@ type Options = {
 }
 
 declare module 'ember-cookies/test-support' {
-  export default function clearAllCookies(param?: Options): void
+  export function clearAllCookies(param?: Options): void
 }
 
 declare module "ember-cookies/services/cookies" {


### PR DESCRIPTION
ClearAllCookies method was not exported as default.
But the type mistakenly exported as default the Pr fix the type.