### PR TITLE
chore(ci): use pull_request_target event to allow continue-on-error-comment to work for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - 'v*'
-  pull_request: {}
+  pull_request_target: {}
   schedule:
     - cron:  '0 3 * * *' # daily, at 3am
 


### PR DESCRIPTION
- Changes the CI trigger event from `pull_request` to `pull_request_target` so the action can create comments on PRs coming from forks.
Also limits the permissions for that workflow as per guides
https://github.com/mainmatter/continue-on-error-comment/releases/tag/v1.2