### PR TITLE
chore(deps): remove ember-data

### DIFF
--- a/packages/test-app/config/ember-try.js
+++ b/packages/test-app/config/ember-try.js
@@ -19,7 +19,6 @@ module.exports = function () {
           name: 'ember-4.0',
           npm: {
             devDependencies: {
-              'ember-data': '~4.0.0',
               'ember-source': '~4.0.0',
             },
           },
@@ -28,7 +27,6 @@ module.exports = function () {
           name: 'ember-lts-4.4',
           npm: {
             devDependencies: {
-              'ember-data': '~4.4.0',
               'ember-source': '~4.4.0',
             },
           },
@@ -37,7 +35,6 @@ module.exports = function () {
           name: 'ember-lts-4.8',
           npm: {
             devDependencies: {
-              'ember-data': '~4.8.0',
               'ember-source': '~4.8.0',
             },
           },
@@ -46,7 +43,6 @@ module.exports = function () {
           name: 'ember-4.12',
           npm: {
             devDependencies: {
-              'ember-data': '~4.12.0',
               'ember-source': '~4.12.0',
             },
           },
@@ -55,7 +51,6 @@ module.exports = function () {
           name: 'ember-release',
           npm: {
             devDependencies: {
-              'ember-data': 'latest',
               'ember-source': releaseUrl,
             },
           },
@@ -64,7 +59,6 @@ module.exports = function () {
           name: 'ember-beta',
           npm: {
             devDependencies: {
-              'ember-data': 'beta',
               'ember-source': betaUrl,
             },
           },
@@ -73,7 +67,6 @@ module.exports = function () {
           name: 'ember-canary',
           npm: {
             devDependencies: {
-              'ember-data': 'canary',
               'ember-source': canaryUrl,
             },
           },


### PR DESCRIPTION
- Removes ember-data from try scenarios
We don't use it in the project at all, not even for testing and its breaking the builds.