### PR TITLE
Support Partitioned Cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start:addon": "pnpm --filter ember-cookies start",
     "start:test-app": "pnpm --filter test-app start",
     "test": "pnpm run test:test-app ember-default",
+    "test:all": "pnpm --filter test-app test:all",
     "test:test-app": "pnpm --filter test-app test:one",
     "test:watch": "concurrently \"pnpm test:watch:test-app\" \"pnpm test:watch:addon\"",
     "test:watch:addon": "pnpm --filter ember-cookies start",

--- a/packages/ember-cookies/src/utils/serialize-cookie.js
+++ b/packages/ember-cookies/src/utils/serialize-cookie.js
@@ -24,6 +24,9 @@ export const serializeCookie = (name, value, options = {}) => {
   if (!isEmpty(options.sameSite)) {
     cookie = `${cookie}; SameSite=${options.sameSite}`;
   }
+  if (options.partitioned) {
+    cookie = `${cookie}; Partitioned`;
+  }
 
   return cookie;
 };

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -44,7 +44,7 @@
     "ember-cli-inject-live-reload": "2.1.0",
     "ember-cli-sri": "2.1.1",
     "ember-cli-terser": "4.0.2",
-    "ember-cookies": "1.1.2",
+    "ember-cookies": "link:../ember-cookies",
     "ember-disable-prototype-extensions": "1.1.3",
     "ember-load-initializers": "2.1.2",
     "ember-maybe-import-regenerator": "1.0.0",

--- a/packages/test-app/tests/unit/services/cookies-test.js
+++ b/packages/test-app/tests/unit/services/cookies-test.js
@@ -289,6 +289,17 @@ module('CookiesService', function (hooks) {
           this.cookies.write(COOKIE_NAME, 'test', { secure: true });
         });
 
+        test('sets the partitioned flag', function (assert) {
+          assert.expect(1);
+          defineProperty(this.fakeDocument, 'cookie', {
+            set(value) {
+              assert.ok(value.includes('; Partitioned'));
+            },
+          });
+
+          this.cookies.write(COOKIE_NAME, 'test', { partitioned: true });
+        });
+
         test('sets the path', function (assert) {
           assert.expect(1);
           defineProperty(this.fakeDocument, 'cookie', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       ember-cookies:
-        specifier: 1.1.2
-        version: 1.1.2
+        specifier: link:../ember-cookies
+        version: link:../ember-cookies
       ember-disable-prototype-extensions:
         specifier: 1.1.3
         version: 1.1.3
@@ -3055,10 +3055,6 @@ packages:
   ember-compatibility-helpers@1.2.7:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
-
-  ember-cookies@1.1.2:
-    resolution: {integrity: sha512-6GaN0eEDZT9SEUSZBxWzZMlvxjcGKXFTJNjv30LVXTTOxozE5IBmIxiDAEq0udi0UpWUGHLYQBgnANn4jdll7w==}
-    engines: {node: '>= 16.*'}
 
   ember-disable-prototype-extensions@1.1.3:
     resolution: {integrity: sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==}
@@ -8439,26 +8435,6 @@ snapshots:
     dependencies:
       '@types/node': 22.5.5
 
-  '@types/ember@4.0.11':
-    dependencies:
-      '@types/ember__application': 4.0.11(@babel/core@7.25.8)
-      '@types/ember__array': 4.0.10(@babel/core@7.25.8)
-      '@types/ember__component': 4.0.22
-      '@types/ember__controller': 4.0.12(@babel/core@7.25.8)
-      '@types/ember__debug': 4.0.8(@babel/core@7.25.8)
-      '@types/ember__engine': 4.0.11(@babel/core@7.25.8)
-      '@types/ember__error': 4.0.6
-      '@types/ember__object': 4.0.12(@babel/core@7.25.8)
-      '@types/ember__polyfills': 4.0.6
-      '@types/ember__routing': 4.0.22
-      '@types/ember__runloop': 4.0.10
-      '@types/ember__service': 4.0.9(@babel/core@7.25.8)
-      '@types/ember__string': 3.0.15
-      '@types/ember__template': 4.0.7
-      '@types/ember__test': 4.0.6(@babel/core@7.25.8)
-      '@types/ember__utils': 4.0.7(@babel/core@7.25.8)
-      '@types/rsvp': 4.0.9
-
   '@types/ember@4.0.11(@babel/core@7.25.8)':
     dependencies:
       '@types/ember__application': 4.0.11(@babel/core@7.25.8)
@@ -8485,11 +8461,11 @@ snapshots:
   '@types/ember__application@4.0.11(@babel/core@7.25.8)':
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.25.8)
-      '@types/ember': 4.0.11
+      '@types/ember': 4.0.11(@babel/core@7.25.8)
       '@types/ember__engine': 4.0.11(@babel/core@7.25.8)
       '@types/ember__object': 4.0.12(@babel/core@7.25.8)
       '@types/ember__owner': 4.0.9
-      '@types/ember__routing': 4.0.22
+      '@types/ember__routing': 4.0.22(@babel/core@7.25.8)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8501,11 +8477,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  '@types/ember__component@4.0.22':
-    dependencies:
-      '@types/ember': 4.0.11
-      '@types/ember__object': 4.0.12(@babel/core@7.25.8)
 
   '@types/ember__component@4.0.22(@babel/core@7.25.8)':
     dependencies:
@@ -8552,13 +8523,6 @@ snapshots:
 
   '@types/ember__polyfills@4.0.6': {}
 
-  '@types/ember__routing@4.0.22':
-    dependencies:
-      '@types/ember': 4.0.11
-      '@types/ember__controller': 4.0.12(@babel/core@7.25.8)
-      '@types/ember__object': 4.0.12(@babel/core@7.25.8)
-      '@types/ember__service': 4.0.9(@babel/core@7.25.8)
-
   '@types/ember__routing@4.0.22(@babel/core@7.25.8)':
     dependencies:
       '@types/ember': 4.0.11(@babel/core@7.25.8)
@@ -8568,10 +8532,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  '@types/ember__runloop@4.0.10':
-    dependencies:
-      '@types/ember': 4.0.11
 
   '@types/ember__runloop@4.0.10(@babel/core@7.25.8)':
     dependencies:
@@ -10663,12 +10623,6 @@ snapshots:
       semver: 5.7.2
     transitivePeerDependencies:
       - '@babel/core'
-      - supports-color
-
-  ember-cookies@1.1.2:
-    dependencies:
-      '@embroider/addon-shim': 1.8.9
-    transitivePeerDependencies:
       - supports-color
 
   ember-disable-prototype-extensions@1.1.3: {}


### PR DESCRIPTION
Adds support for Partitioned Cookies. Useful for third party cookies. See https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies